### PR TITLE
Fix issues on build on Linux

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -37,6 +37,8 @@
 #endif
 #endif
 
+#include <deque>
+
 /** Maximum size of http request (request line + headers) */
 static const size_t MAX_HEADERS_SIZE = 8192;
 

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -132,7 +132,8 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
 
     int nRootCerts = 0;
     const QDateTime currentTime = QDateTime::currentDateTime();
-    Q_FOREACH (const QSslCertificate& cert, certList) {
+    //Q_FOREACH (const QSslCertificate& cert, certList) {
+    for (const QSslCertificate& cert : certList) {
         if (currentTime < cert.effectiveDate() || currentTime > cert.expiryDate()) {
             ReportInvalidCertificate(cert);
             continue;
@@ -229,7 +230,8 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 bool PaymentServer::ipcSendCommandLine()
 {
     bool fResult = false;
-    Q_FOREACH (const QString& r, savedPaymentRequests) {
+    //Q_FOREACH (const QString& r, savedPaymentRequests) {
+    for (const QString& r : savedPaymentRequests) {
         QLocalSocket* socket = new QLocalSocket();
         socket->connectToServer(ipcServerName(), QIODevice::WriteOnly);
         if (!socket->waitForConnected(BITCOIN_IPC_CONNECT_TIMEOUT)) {
@@ -346,7 +348,8 @@ void PaymentServer::uiReady()
     initNetManager();
 
     saveURIs = false;
-    Q_FOREACH (const QString& s, savedPaymentRequests) {
+    //Q_FOREACH (const QString& s, savedPaymentRequests) {
+    for (const QString& s : savedPaymentRequests) {
         handleURIOrFile(s);
     }
     savedPaymentRequests.clear();
@@ -498,7 +501,8 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    Q_FOREACH (const PAIRTYPE(CScript, CAmount) & sendingTo, sendingTos) {
+    //Q_FOREACH (const PAIRTYPE(CScript, CAmount) & sendingTo, sendingTos) {
+    for (const PAIRTYPE(CScript, CAmount) & sendingTo : sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {
@@ -650,7 +654,8 @@ void PaymentServer::reportSslErrors(QNetworkReply* reply, const QList<QSslError>
     Q_UNUSED(reply);
 
     QString errString;
-    Q_FOREACH (const QSslError& err, errs) {
+    //Q_FOREACH (const QSslError& err, errs) {
+    for (const QSslError& err : errs) {
         qWarning() << "PaymentServer::reportSslErrors : " << err;
         errString += err.errorString() + "\n";
     }

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -8,6 +8,7 @@
 
 #include "fs.h"
 #include "txdb.h"
+#include "random.h"
 
 #include <boost/thread.hpp>
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -11,6 +11,10 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/shared_ptr.hpp>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 class CBlock;
 struct CBlockLocator;
 class CBlockIndex;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1069,16 +1069,16 @@ bool AttemptBackupWallet(const CWallet& wallet, const fs::path& pathSrc, const f
             LogPrintf("cannot backup to wallet source file %s\n", pathDest.string());
             return false;
         }
-#if BOOST_VERSION >= 105800 /* BOOST_LIB_VERSION 1_58 */
-        fs::copy_file(pathSrc.c_str(), pathDest, fs::copy_option::overwrite_if_exists);
-#else
+//#if BOOST_VERSION >= 105800 /* BOOST_LIB_VERSION 1_58 */
+//        fs::copy_file(pathSrc.c_str(), pathDest, fs::copy_option::overwrite_if_exists);
+//#else
         std::ifstream src(pathSrc.c_str(),  std::ios::binary | std::ios::in);
         std::ofstream dst(pathDest.c_str(), std::ios::binary | std::ios::out | std::ios::trunc);
         dst << src.rdbuf();
         dst.flush();
         src.close();
         dst.close();
-#endif
+//#endif
         strMessage = strprintf("copied %s to %s\n", wallet.strWalletFile, pathDest.string());
         LogPrintf("%s : %s\n", __func__, strMessage);
         retStatus = true;


### PR DESCRIPTION
Hello, I corrected some issues while built on Linux

g++ (Debian 12.2.0-14) 12.2.0
uname -a
Linux devuan 6.1.0-28-rt-amd64 #1 SMP PREEMPT_RT Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
lsb_release -a
No LSB modules are available.
Distributor ID:	Devuan
Description:	Devuan GNU/Linux 5 (daedalus)
Release:	5
Codename:	daedalus

Here
alias v='vim'
alias mk='make'


I just added some includes and also replaced Q_FOREACH (that is already deprecated and removed) with just simple for:
```

wget https://github.com/mandikechain/XMD/archive/refs/tags/2.0.tar.gz
tar -xf 2.0.tar.gz
cd XMD-2.0
./autogen.sh
./configure --with-incompatible-bdb
mk
  /usr/include/openssl/sha.h:76:27: note: declared here
     76 | OSSL_DEPRECATEDIN_3_0 int SHA256_Final(unsigned char *md, SHA256_CTX *c);
        |                           ^~~~~~~~~~~~
    CXX      libbitcoin_server_a-httpserver.o
  httpserver.cpp:74:10: error: ‘deque’ in namespace ‘std’ does not name a template type
     74 |     std::deque<WorkItem*> queue;
        |          ^~~~~
  httpserver.cpp:32:1: note: ‘std::deque’ is defined in header ‘<deque>’; did you forget to ‘#include <deque>’?
     31 | #include <event2/keyvalq_struct.h>
    +++ |+#include <deque>
     32 | 
v src/httpserver.cpp
  40: #include <deque>
mk
  validationinterface.cpp: In function ‘void RegisterValidationInterface(CValidationInterface*)’:
  validationinterface.cpp:19:102: error: ‘_1’ was not declared in this scope
     19 |     g_signals.UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1));
        |                                                                                                      ^~
v src/validationinterface.h
  14:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
mk
  In file included from ./primitives/block.h:11,
                   from ./chainparams.h:19,
                   from ./base58.h:19,
                   from wallet/walletdb.cpp:13:
  ./primitives/transaction.h:255:19: note: because ‘CTransaction’ has user-provided ‘CTransaction& CTransaction::operator=(const CTransaction&)’
    255 |     CTransaction& operator=(const CTransaction& tx);
        |                   ^~~~~~~~
  wallet/walletdb.cpp: In function ‘bool AttemptBackupWallet(const CWallet&, const boost::filesystem::path&, const boost::filesystem::path&)’:
  wallet/walletdb.cpp:1073:54: error: ‘fs::copy_option’ has not been declared
   1073 |         fs::copy_file(pathSrc.c_str(), pathDest, fs::copy_option::overwrite_if_exists);
        |                                                      ^~~~~~~~~~~
v src/wallet/walletdb.cpp
  1072://#if BOOST_VERSION >= 105800 /* BOOST_LIB_VERSION 1_58 */
  //        fs::copy_file(pathSrc.c_str(), pathDest, fs::copy_option::overwrite_if_exists);
  //#else
  1081://#endif
mk
  /usr/include/openssl/sha.h:76:27: note: declared here
     76 | OSSL_DEPRECATEDIN_3_0 int SHA256_Final(unsigned char *md, SHA256_CTX *c);
        |                           ^~~~~~~~~~~~
  test/test_pivx.h: At global scope:
  test/test_pivx.h:15:8: error: ‘FastRandomContext’ does not name a type
     15 | extern FastRandomContext insecure_rand_ctx;
        |        ^~~~~~~~~~~~~~~~~
  test/test_pivx.h: In function ‘void SeedInsecureRand(bool)’:
  test/test_pivx.h:22:30: error: ‘GetRandHash’ was not declared in this scope
     22 |         insecure_rand_seed = GetRandHash();
        |                              ^~~~~~~~~~~
v src/test/test_pivx.h
cd ../../../networks/
find . -type f -name '*.cpp' -exec grep -l FastRandomContext {} \; > ~/1
find . -type f -name '*test_pivx.h' -exec grep -l FastRandomContext {} \;
  ./xln/LunariumCoin-2.0-2.0.2.0/src/test/test_pivx.h
  ./xln/my-fix/LunariumCoin-2.0/src/test/test_pivx.h
  ./xln/my-fix/compile/LunariumCoin-2.0/src/test/test_pivx.h

diff ../testing/xmd/XMD-2.0/src/test/test_pivx.h ./xln/my-fix/LunariumCoin-2.0/src/test/test_pivx.h
  2c2
  < // Copyright (c) 2021 The DECENOMY Core Developers
  ---
  > // Copyright (c) 2021-2022 The LUNARIUMCOIN Core Developers
  10a11
  > #include "random.h"
v src/test/test_pivx.h
  12:#include "random.h"
mk
  /usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:1511:20: note: declared here
   1511 | inline QByteArray &QByteArray::append(const QString &s)
        |                    ^~~~~~~~~~
  qt/paymentserver.cpp: In member function ‘bool PaymentServer::processPaymentRequest(PaymentRequestPlus&, SendCoinsRecipient&)’:
  /usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1133:5: error: ‘Q_FOREACH_IMPL’ was not declared in this scope
   1133 |     Q_FOREACH_IMPL(variable, Q_FOREACH_JOIN(_container_, __LINE__), container)
        |     ^~~~~~~~~~~~~~
v src/qt/paymentserver.cpp
  135://Q_FOREACH (const QSslCertificate& cert, certList) {
  for (const QSslCertificate& cert : certList) {
  233://Q_FOREACH (const QString& r, savedPaymentRequests) {
    for (const QString& r : savedPaymentRequests) {
  351://Q_FOREACH (const QString& s, savedPaymentRequests) {
    for (const QString& s : savedPaymentRequests) {
  504://Q_FOREACH (const PAIRTYPE(CScript, CAmount) & sendingTo, sendingTos) {
    for (const PAIRTYPE(CScript, CAmount) & sendingTo : sendingTos) {
  657://Q_FOREACH (const QSslError& err, errs) {
    for (const QSslError& err : errs) {
mk
  ./primitives/transaction.h:255:19: note: because ‘CTransaction’ has user-provided ‘CTransaction& CTransaction::operator=(const CTransaction&)’
    255 |     CTransaction& operator=(const CTransaction& tx);
        |                   ^~~~~~~~
    CXXLD    qt/test/test_pivx-qt
  make[2]: Leaving directory '/mnt/blockchains/crypto/testing/xmd/XMD-2.0/src'
  make[1]: Leaving directory '/mnt/blockchains/crypto/testing/xmd/XMD-2.0/src'
  Making all in doc/man
  make[1]: Entering directory '/mnt/blockchains/crypto/testing/xmd/XMD-2.0/doc/man'
  make[1]: Nothing to be done for 'all'.
  make[1]: Leaving directory '/mnt/blockchains/crypto/testing/xmd/XMD-2.0/doc/man'
  make[1]: Entering directory '/mnt/blockchains/crypto/testing/xmd/XMD-2.0'
  make[1]: Nothing to be done for 'all-am'.
  make[1]: Leaving directory '/mnt/blockchains/crypto/testing/xmd/XMD-2.0'
  Fri Dec 13 05:24:10 PM MSK 2024
  start date was Fri Dec 13 05:17:11 PM MSK 2024
./src/qt/mandike-qt
  #now it works!
```

Then I forked and fixed again in my repo and build from first time straightaway without errors.